### PR TITLE
Fixed Buffer overflow in http.c

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -149,8 +149,8 @@ void parse_uri(char *uri, int uri_length, char *filename, char *querystring) {
         file_length = uri_length;
     }
 
-    strcpy(filename, ROOT);
-    strncat(filename, uri, file_length);
+    strncpy(filename, ROOT, SHORTLINE - 1 );
+    strncat(filename, uri, SHORTLINE - strlen(filename) - 1);
 
     char *last_comp = rindex(filename, '/');
     char *last_dot = rindex(last_comp, '.');


### PR DESCRIPTION
found buffer overflow which causes the server to crash via fuzzing.

Image of metasploit fuzzer:

![image](https://cloud.githubusercontent.com/assets/12894505/12247185/22d47996-b8b3-11e5-8e71-d9ab8386b7e6.png)

log on the server:

![image](https://cloud.githubusercontent.com/assets/12894505/12247210/3d44d712-b8b3-11e5-8e51-7cd28e29b330.png)
