### PR TITLE
docs: fix simple typo, accpet -> accept

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -51,7 +51,7 @@ int open_listenfd(int port)
 }
 
 /*
-    make a socket non blocking. If a listen socket is a blocking socket, after it comes out from epoll and accepts the last connection, the next accpet will block, which is not what we want
+    make a socket non blocking. If a listen socket is a blocking socket, after it comes out from epoll and accepts the last connection, the next accept will block, which is not what we want
 */
 int make_socket_non_blocking(int fd) {
     int flags, s;


### PR DESCRIPTION
There is a small typo in src/util.c.

Should read `accept` rather than `accpet`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md